### PR TITLE
Fix PHP nightly tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,15 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4snapshot
+      addons:
+        apt:
+          packages:
+            - libonig-dev
     - php: nightly
+      addons:
+        apt:
+          packages:
+            - libonig-dev
   allow_failures:
     - php: 7.4snapshot
     - php: nightly


### PR DESCRIPTION
Test fail with the following message:

```
php: error while loading shared libraries: libonig.so.2: cannot open shared object file: No such file or directory
```

https://github.com/travis-ci/php-src-builder/pull/31